### PR TITLE
Fix provisioning issues

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -24,7 +24,7 @@ Download the source and verify that you can build it in your local development e
 
 ### 3. Provision your environment
 
-All three deployment options use an Event Hub which you must configure before you run the RI. You can configure an Event Hub manually using the Azure Management portal but we recommend you use the **ProvisionAssets.ps1** PowerShell script located in the **Deployment** folder included in the Visual Studio solution you downloaded. This script also provisions the Azure Storage account that deployment option #3 requires and modifies the configuration files in your Visual Studio solution to include details of the Event Hub and Storage account.
+All three deployment options use an Event Hub which you must configure before you run the RI. You can configure an Event Hub manually using the Azure Management portal but we recommend you use the **ProvisionAssets.ps1** PowerShell script located in the **Provisioning** folder included in the Visual Studio solution you downloaded. This script also provisions the Azure Storage account that deployment option #3 requires and modifies the configuration files in your Visual Studio solution to include details of the Event Hub and Storage account.
 
 This script prompts prompts you for the following information:
 

--- a/src/Provisioning/CreateEventHub.ps1
+++ b/src/Provisioning/CreateEventHub.ps1
@@ -56,8 +56,8 @@
 [CmdletBinding(PositionalBinding=$True)] 
 Param( 
     [Parameter(Mandatory = $true)] 
-    [ValidatePattern("^[a-z0-9]*$")] 
-    [String]$Path,                                  # required    needs to be alphanumeric     
+    [ValidatePattern("^[A-Za-z0-9]$|^[A-Za-z0-9][\w-\.\/]*[A-Za-z0-9]$")] 
+    [String]$Path,                                  # required    needs to start with letter or number, and contain only letters, numbers, periods, hyphens, and underscores.
     [Int]$PartitionCount = 16,                      # optional    default to 16 
     [Int]$MessageRetentionInDays = 7,               # optional    default to 7 
     [String]$UserMetadata = $null,                  # optional    default to $null 
@@ -65,8 +65,8 @@ Param(
     [string]$DispatcherConsumerGroupName = "Dispatcher",
     [String]$ConsumerGroupUserMetadata = $null,     # optional    default to $null 
     [Parameter(Mandatory = $true)] 
-    [ValidatePattern("^[a-z0-9]*$")] 
-    [String]$Namespace,                             # required    needs to be alphanumeric 
+    [ValidatePattern("^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$")] 
+    [String]$Namespace,                             # required    needs to start with letter or number, and contain only letters, numbers, and hyphens.
     [Bool]$CreateACSNamespace = $false,             # optional    default to $false 
     [String]$Location = "West Europe"          # optional    default to "West Europe" 
     ) 

--- a/src/Provisioning/ProvisionAssets.ps1
+++ b/src/Provisioning/ProvisionAssets.ps1
@@ -85,7 +85,7 @@ if(-not(Get-Module -name "Azure"))
     }
     else
     {
-        "Windows Azure Powershell has not been installed."
+        "Microsoft Azure Powershell has not been installed, or cannot be found."
         Exit
     }
 }

--- a/src/Provisioning/ProvisionAssets.ps1
+++ b/src/Provisioning/ProvisionAssets.ps1
@@ -46,11 +46,11 @@ Param
 	[string] $SubscriptionName,
 
     [Parameter (Mandatory = $true)]
-    [ValidatePattern("^[a-z0-9]*$")] 
+    [ValidatePattern("^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$")] 
     [string] $ServiceBusNamespace,
 
     [Parameter (Mandatory = $true)]
-    [ValidatePattern("^[a-z0-9]*$")] 
+    [ValidatePattern("^[A-Za-z0-9]$|^[A-Za-z0-9][\w-\.\/]*[A-Za-z0-9]$")] 
     [string] $ServiceBusEventHubPath,
 
     [Parameter (Mandatory = $true)]

--- a/src/Provisioning/ProvisionAssets.ps1
+++ b/src/Provisioning/ProvisionAssets.ps1
@@ -119,7 +119,7 @@ $scriptPath = Split-Path (Get-Variable MyInvocation -Scope 0).Value.MyCommand.Pa
 .\CopyOutputToConfigFile.ps1 -configurationFile "..\RunFromConsole\mysettings.config" -appSettings $settings
 
 # get Cloud service configuration files 
-$serviceConfigFiles = Get-ChildItem -Include "ServiceConfiguration.Cloud.cscfg" -Path $scriptPath -Recurse
+$serviceConfigFiles = Get-ChildItem -Include "ServiceConfiguration.Cloud.cscfg" -Path "$($scriptPath)\.." -Recurse
 .\CopyOutputToServiceConfigFiles.ps1 -serviceConfigFiles $serviceConfigFiles -appSettings $settings
 
 ""

--- a/src/Provisioning/ProvisionAssets.ps1
+++ b/src/Provisioning/ProvisionAssets.ps1
@@ -54,6 +54,7 @@ Param
     [string] $ServiceBusEventHubPath,
 
     [Parameter (Mandatory = $true)]
+    [ValidatePattern("^[a-z0-9]*$")]
     [String]$StorageAccountName,
 
     [Parameter (Mandatory = $true)]

--- a/src/Provisioning/ProvisionAssets.ps1
+++ b/src/Provisioning/ProvisionAssets.ps1
@@ -76,7 +76,18 @@ Param
 $ErrorActionPreference = "Stop"
 
 # Check the azure module is installed
-Import-Module azure
+if(-not(Get-Module -name "Azure")) 
+{ 
+    if(Get-Module -ListAvailable | Where-Object { $_.name -eq "Azure" }) 
+    { 
+        Import-Module Azure
+    }
+    else
+    {
+        "Windows Azure Powershell has not been installed."
+        Exit
+    }
+}
 
 Add-AzureAccount
 Select-AzureSubscription -SubscriptionName $SubscriptionName


### PR DESCRIPTION
I'm walking through the getting started documentation, and I found a few issues:
- The docs reference the **Deployment** folder, which doesn't exist.  The scripts are in the **Provisioning** folder.
- At the end of the `ProvisionAssets` script, the copy operation failed.  This is because it was looking for the cscfg files in the wrong directory.  Fixed to search from the parent directory.
- The check for the Azure powershell module will fail and abort the script if it can't find the module in `$env:PSModulePath` - even if it's already loaded.  Fixed the script to check if the module is loaded, and only install it if it's not.  (Note, it's still possible that the module is unloaded and not in the path, in which case the error message will show)
